### PR TITLE
Improved micro-catchment workbook import and export

### DIFF
--- a/location/micro_catchment_workbook.py
+++ b/location/micro_catchment_workbook.py
@@ -175,7 +175,7 @@ def build_workbook(district):
 
     # Keep an immediately usable blank row when a district has no catchments yet.
     if sheet.max_row == 1:
-        sheet.append(("", "", "", district.code, "", "", "", ""))
+        sheet.append(("", "", "", district.code, "", "", "", "", "", ""))
 
     _format_sheet(sheet)
     output = BytesIO()

--- a/location/micro_catchment_workbook.py
+++ b/location/micro_catchment_workbook.py
@@ -1,5 +1,6 @@
+import csv
 from datetime import date, datetime
-from io import BytesIO
+from io import BytesIO, StringIO
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -12,6 +13,20 @@ from core.utils import TimeUtils
 from .models import Location, MicroCatchment, MicroCatchmentGVH, MicroCatchmentTA
 
 
+CSV_HEADERS = (
+    "district_code",
+    "district_name",
+    "ta_code",
+    "ta_name",
+    "gvh_code",
+    "gvh_name",
+    "micro_catchment_code",
+    "micro_catchment_name",
+    "start_date",
+    "end_date",
+)
+
+
 HEADERS = (
     "code",
     "name",
@@ -22,6 +37,51 @@ HEADERS = (
     "date_from",
     "date_to",
 )
+
+EXPORT_HEADERS = (
+    "code",
+    "micro_catchment_name",
+    "type",
+    "district_code",
+    "ta_code",
+    "ta_name",
+    "gvh_code",
+    "gvh_name",
+    "date_from",
+    "date_to",
+)
+
+
+def build_template_workbook(district):
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "MicroCatchments"
+    sheet.append(CSV_HEADERS)
+    traditional_authorities = Location.objects.filter(
+        type="D",
+        parent=district,
+        validity_to__isnull=True,
+    ).order_by("code")
+    rows_written = False
+    for ta in traditional_authorities:
+        gvhs = Location.objects.filter(
+            type="W",
+            parent=ta,
+            validity_to__isnull=True,
+        ).order_by("code")
+        ta_has_gvhs = False
+        for gvh in gvhs:
+            sheet.append((district.code, district.name, ta.code, ta.name, gvh.code, gvh.name, "", "", "", ""))
+            rows_written = ta_has_gvhs = True
+        if not ta_has_gvhs:
+            sheet.append((district.code, district.name, ta.code, ta.name, "", "", "", "", "", ""))
+            rows_written = True
+    if not rows_written:
+        sheet.append((district.code, district.name, "", "", "", "", "", "", "", ""))
+    _format_sheet(sheet)
+    output = BytesIO()
+    workbook.save(output)
+    return output.getvalue()
 
 
 def _cell_text(value):
@@ -64,7 +124,7 @@ def build_workbook(district):
     workbook = Workbook()
     sheet = workbook.active
     sheet.title = "MicroCatchments"
-    sheet.append(HEADERS)
+    sheet.append(EXPORT_HEADERS)
 
     catchments = (
         MicroCatchment.objects.filter(district=district, validity_to__isnull=True)
@@ -72,58 +132,55 @@ def build_workbook(district):
         .order_by("code")
     )
     for catchment in catchments:
-        ta_codes = catchment.traditional_authorities.filter(
-            validity_to__isnull=True
-        ).values_list("location__code", flat=True)
-        gvh_codes = catchment.gvhs.filter(validity_to__isnull=True).values_list(
-            "location__code", flat=True
-        )
-        sheet.append(
+        ta_locations = [
+            link.location
+            for link in catchment.traditional_authorities.filter(
+                validity_to__isnull=True
+            ).select_related("location")
+        ]
+        gvh_locations = [
+            link.location
+            for link in catchment.gvhs.filter(
+                validity_to__isnull=True
+            ).select_related("location__parent")
+        ]
+
+        rows = [
             (
-                catchment.code,
-                catchment.name,
-                catchment.type or "",
-                district.code,
-                ",".join(ta_codes),
-                ",".join(gvh_codes),
-                catchment.date_from,
-                catchment.date_to,
+                gvh.parent.code if gvh.parent else "",
+                gvh.parent.name if gvh.parent else "",
+                gvh.code,
+                gvh.name,
             )
-        )
+            for gvh in gvh_locations
+        ]
+        if not rows:
+            rows = [(ta.code, ta.name, "", "") for ta in ta_locations] or [("", "", "", "")]
+
+        for ta_code, ta_name, gvh_code, gvh_name in rows:
+            sheet.append(
+                (
+                    catchment.code,
+                    catchment.name,
+                    catchment.type or "",
+                    district.code,
+                    ta_code,
+                    ta_name,
+                    gvh_code,
+                    gvh_name,
+                    catchment.date_from,
+                    catchment.date_to,
+                )
+            )
 
     # Keep an immediately usable blank row when a district has no catchments yet.
     if sheet.max_row == 1:
         sheet.append(("", "", "", district.code, "", "", "", ""))
 
-    reference = workbook.create_sheet("DistrictLocations")
-    reference.append(("type", "code", "name", "parent_code"))
-    locations = Location.objects.filter(
-        validity_to__isnull=True,
-        type__in=("W", "V"),
-    ).filter(
-        models_for_district(district)
-    ).select_related("parent").order_by("type", "code")
-    for location in locations:
-        reference.append(
-            (
-                "TA" if location.type == "W" else "GVH",
-                location.code,
-                location.name,
-                location.parent.code if location.parent else "",
-            )
-        )
-
     _format_sheet(sheet)
-    _format_sheet(reference)
     output = BytesIO()
     workbook.save(output)
     return output.getvalue()
-
-
-def models_for_district(district):
-    from django.db.models import Q
-
-    return Q(type="W", parent=district) | Q(type="V", parent__parent=district)
 
 
 def parse_workbook(uploaded_file, district):
@@ -231,6 +288,124 @@ def parse_workbook(uploaded_file, district):
 @transaction.atomic
 def import_workbook(uploaded_file, district, audit_user_id):
     records = parse_workbook(uploaded_file, district)
+    return import_records(records, district, audit_user_id)
+
+
+def import_csv(uploaded_file, district, audit_user_id):
+    try:
+        content = uploaded_file.read().decode("utf-8-sig")
+        reader = csv.DictReader(StringIO(content))
+        supplied_headers = tuple((header or "").strip().lower() for header in (reader.fieldnames or ()))
+    except (UnicodeDecodeError, csv.Error) as exc:
+        raise ValidationError("The uploaded file is not a valid UTF-8 CSV file.") from exc
+
+    missing = [header for header in CSV_HEADERS if header not in supplied_headers]
+    if missing:
+        raise ValidationError("Missing required columns: %s." % ", ".join(missing))
+
+    grouped = {}
+    errors = []
+    for row_number, row in enumerate(reader, start=2):
+        values = {(key or "").strip().lower(): _cell_text(value) for key, value in row.items()}
+        code = values["micro_catchment_code"]
+        name = values["micro_catchment_name"]
+        ta_code = values["ta_code"]
+        gvh_code = values["gvh_code"]
+        if not code and not name:
+            continue
+
+        row_errors = []
+        if values["district_code"] != district.code:
+            row_errors.append(f"district_code must be {district.code}")
+        if not code:
+            row_errors.append("micro_catchment_code is required")
+        if not name:
+            row_errors.append("micro_catchment_name is required")
+        ta = Location.objects.filter(
+            code=ta_code,
+            type="D",
+            parent=district,
+            validity_to__isnull=True,
+        ).first()
+        if not ta:
+            row_errors.append(f"invalid TA code: {ta_code}")
+        gvh = None
+        if gvh_code and ta:
+            gvh = Location.objects.filter(
+                code=gvh_code,
+                type="W",
+                parent=ta,
+                validity_to__isnull=True,
+            ).first()
+            if not gvh:
+                row_errors.append(f"invalid GVH code: {gvh_code}")
+        try:
+            start_date = _date(values["start_date"], "start_date", row_number)
+            end_date = _date(values["end_date"], "end_date", row_number)
+            if start_date and end_date and end_date < start_date:
+                row_errors.append("end_date cannot be before start_date")
+        except ValidationError as exc:
+            row_errors.extend(exc.messages)
+            start_date = end_date = None
+        if row_errors:
+            errors.append("Row %s: %s." % (row_number, "; ".join(row_errors)))
+            continue
+
+        record = grouped.setdefault(
+            code,
+            {"name": name, "tas": [], "gvhs": [], "start_date": start_date, "end_date": end_date},
+        )
+        if record["name"] != name:
+            errors.append(f"Row {row_number}: micro_catchment_name is inconsistent for code {code}.")
+        elif record["start_date"] != start_date or record["end_date"] != end_date:
+            errors.append(f"Row {row_number}: start_date or end_date is inconsistent for code {code}.")
+        elif ta.id not in {location.id for location in record["tas"]}:
+            record["tas"].append(ta)
+        if gvh and gvh.id not in {location.id for location in record["gvhs"]}:
+            record["gvhs"].append(gvh)
+
+    if errors:
+        raise ValidationError(errors)
+    if not grouped:
+        raise ValidationError("The CSV contains no completed micro-catchment rows.")
+
+    records = [
+        {
+            "code": code,
+            "name": values["name"],
+            "type": None,
+            "date_from": values["start_date"],
+            "date_to": values["end_date"],
+            "tas": values["tas"],
+            "gvhs": values["gvhs"],
+        }
+        for code, values in grouped.items()
+    ]
+    return import_records(records, district, audit_user_id)
+
+
+def import_excel(uploaded_file, district, audit_user_id):
+    try:
+        workbook = load_workbook(uploaded_file, data_only=True, read_only=True)
+        sheet = workbook["MicroCatchments"]
+        first_row = next(sheet.iter_rows(values_only=True))
+        headers = tuple(_cell_text(value).lower() for value in first_row)
+    except Exception as exc:
+        raise ValidationError("The uploaded file is not a valid MicroCatchments workbook.") from exc
+
+    uploaded_file.seek(0)
+    if all(header in headers for header in CSV_HEADERS):
+        output = StringIO(newline="")
+        writer = csv.writer(output)
+        for row in sheet.iter_rows(values_only=True):
+            writer.writerow(row)
+        converted = BytesIO(output.getvalue().encode("utf-8-sig"))
+        return import_csv(converted, district, audit_user_id)
+    return import_workbook(uploaded_file, district, audit_user_id)
+
+
+@transaction.atomic
+def import_records(records, district, audit_user_id):
     now = TimeUtils.now()
     created = updated = 0
 

--- a/location/urls.py
+++ b/location/urls.py
@@ -5,5 +5,6 @@ from . import views
 
 urlpatterns = [
     path("micro-catchments/export/", views.export_micro_catchments),
+    path("micro-catchments/template/", views.download_micro_catchment_template),
     path("micro-catchments/import/", views.import_micro_catchments),
 ]

--- a/location/views.py
+++ b/location/views.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from core.views import check_user_rights
 
 from .apps import LocationConfig
-from .micro_catchment_workbook import build_workbook, import_workbook
+from .micro_catchment_workbook import build_template_workbook, build_workbook, import_csv, import_excel
 from .models import Location, UserDistrict
 
 
@@ -21,14 +21,23 @@ def _district_for_user(request):
     if not district_uuid:
         raise ValidationError("district_uuid is required.")
     district = Location.objects.filter(
-        uuid=district_uuid, type="D", validity_to__isnull=True
+        uuid=district_uuid, type="R", validity_to__isnull=True
     ).first()
     if not district:
         raise ValidationError("District not found.")
-    allowed_ids = {
-        user_district.location_id
-        for user_district in UserDistrict.get_user_districts(request.user)
-    }
+
+    # UserDistrict assignments still point to level-D locations (Traditional
+    # Authorities in the Malawi hierarchy). Export/import operates on the
+    # top-level R location stored by MicroCatchment.district, so authorize the
+    # selected District through the assigned location's parent.
+    allowed_ids = set()
+    for user_district in UserDistrict.get_user_districts(request.user):
+        assigned_location = user_district.location
+        if assigned_location.type == "R":
+            allowed_ids.add(assigned_location.id)
+        elif assigned_location.parent_id:
+            allowed_ids.add(assigned_location.parent_id)
+
     if district.id not in allowed_ids:
         from django.core.exceptions import PermissionDenied
 
@@ -54,6 +63,24 @@ def export_micro_catchments(request):
         return Response({"success": False, "errors": exc.messages}, status=status.HTTP_400_BAD_REQUEST)
 
 
+@api_view(["GET"])
+@permission_classes([check_user_rights(LocationConfig.import_micro_catchments_perms)])
+def download_micro_catchment_template(request):
+    try:
+        district = _district_for_user(request)
+        content = build_template_workbook(district)
+        response = HttpResponse(
+            content,
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+        response["Content-Disposition"] = (
+            f'attachment; filename="micro_catchment_template_{district.code}.xlsx"'
+        )
+        return response
+    except ValidationError as exc:
+        return Response({"success": False, "errors": exc.messages}, status=status.HTTP_400_BAD_REQUEST)
+
+
 @api_view(["POST"])
 @permission_classes([check_user_rights(LocationConfig.import_micro_catchments_perms)])
 def import_micro_catchments(request):
@@ -61,10 +88,14 @@ def import_micro_catchments(request):
         district = _district_for_user(request)
         uploaded_file = request.FILES.get("file")
         if not uploaded_file:
-            raise ValidationError("An .xlsx file is required.")
-        if not uploaded_file.name.lower().endswith(".xlsx"):
-            raise ValidationError("Only .xlsx files are supported.")
-        result = import_workbook(uploaded_file, district, request.user.id_for_audit)
+            raise ValidationError("An .xlsx or .csv file is required.")
+        filename = uploaded_file.name.lower()
+        if filename.endswith(".xlsx"):
+            result = import_excel(uploaded_file, district, request.user.id_for_audit)
+        elif filename.endswith(".csv"):
+            result = import_csv(uploaded_file, district, request.user.id_for_audit)
+        else:
+            raise ValidationError("Only .xlsx and .csv files are supported.")
         return Response({"success": True, **result})
     except ValidationError as exc:
         return Response({"success": False, "errors": exc.messages}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary

Adds an Excel-based template workflow for micro-catchments and improves the structure of exported workbooks.

Changes
- Add an endpoint for downloading a district-specific Excel template.
- Prepopulate the template with the selected District, TAs, and GVHs.
- Include the following template columns:
  - District code and name
  - TA code and name
  - GVH code and name
  - Micro-catchment code and name
  - Optional start and end dates
- Support importing completed `.xlsx` and `.csv` templates.
- Validate District, TA, and GVH relationships during import.
- Keep GVH and date fields optional.
- Create or update micro-catchments
- Export every GVH on an individual row.
- Add TA and GVH names beside their respective codes.
