### PR TITLE
extended hotspot village assignment validation

### DIFF
--- a/location/gql_mutations.py
+++ b/location/gql_mutations.py
@@ -516,7 +516,7 @@ class HotspotInputType(OpenIMISMutation.Input):
     village_uuids = graphene.List(graphene.String, required=True)
 
 
-def get_hotspot_eligible_villages(micro_catchment):
+def get_hotspot_eligible_villages(micro_catchment, hotspot=None):
     """
     Villages (Location type V) that can be attached to a hotspot for the given
     micro-catchment: those whose parent GVH (Location type W under the Malawi
@@ -527,10 +527,19 @@ def get_hotspot_eligible_villages(micro_catchment):
         micro_catchments_gvh__micro_catchment=micro_catchment,
         micro_catchments_gvh__validity_to__isnull=True,
     )
-    return Location.objects.filter(
+    villages = Location.objects.filter(
         *Location.filter_validity(),
         type="V",
         parent__in=gvh_locations,
+    )
+    assigned_villages = HotspotVillage.objects.filter(
+        validity_to__isnull=True,
+        hotspot__validity_to__isnull=True,
+    )
+    if hotspot:
+        assigned_villages = assigned_villages.exclude(hotspot=hotspot)
+    return villages.exclude(
+        id__in=assigned_villages.values_list("location_id", flat=True)
     )
 
 
@@ -555,7 +564,12 @@ def update_or_create_hotspot(data, user):
     except MicroCatchment.DoesNotExist:
         raise ValidationError(_("location.mutation.hotspot_micro_catchment_required"))
 
-    eligible_villages = get_hotspot_eligible_villages(micro_catchment)
+    current_hotspot = None
+    if data.get("uuid"):
+        current_hotspot = Hotspot.objects.filter(
+            uuid=data["uuid"], validity_to__isnull=True
+        ).first()
+    eligible_villages = get_hotspot_eligible_villages(micro_catchment, current_hotspot)
     villages = list(eligible_villages.filter(uuid__in=village_uuids))
     if len(villages) != len(village_uuids):
         raise ValidationError(_("location.mutation.hotspot_invalid_villages"))

--- a/location/schema.py
+++ b/location/schema.py
@@ -101,11 +101,12 @@ class Query(graphene.ObjectType):
     hotspot_eligible_villages = graphene.List(
         LocationGQLType,
         micro_catchment_uuid=graphene.String(required=True),
+        hotspot_uuid=graphene.String(required=False),
         description="Villages selectable for a hotspot in the given micro-catchment "
         "(villages under the micro-catchment's GVHs).",
     )
 
-    def resolve_hotspot_eligible_villages(self, info, micro_catchment_uuid, **kwargs):
+    def resolve_hotspot_eligible_villages(self, info, micro_catchment_uuid, hotspot_uuid=None, **kwargs):
         if info.context.user.is_anonymous:
             raise PermissionDenied(_("unauthorized"))
         try:
@@ -114,7 +115,12 @@ class Query(graphene.ObjectType):
             )
         except MicroCatchment.DoesNotExist:
             return []
-        return get_hotspot_eligible_villages(micro_catchment).order_by("code")
+        hotspot = None
+        if hotspot_uuid:
+            hotspot = Hotspot.objects.filter(
+                uuid=hotspot_uuid, validity_to__isnull=True
+            ).first()
+        return get_hotspot_eligible_villages(micro_catchment, hotspot).order_by("code")
 
     def resolve_hotspots(self, info, **kwargs):
         if info.context.user.is_anonymous:


### PR DESCRIPTION
Improves hotspot village selection to prevent villages from being assigned to multiple active hotspots.

Changes

-Villages assigned to other active hotspots are excluded from the picker.
-The current hotspot UUID is passed when editing a hotspot.
-Villages already belonging to the hotspot being edited remain selectable.