### PR TITLE
Order location filters alphabetically by name (backend)

### DIFF
--- a/location/gql_queries.py
+++ b/location/gql_queries.py
@@ -317,7 +317,7 @@ class CatchmentGQLType(DjangoObjectType):
             catchment_links__validity_to__isnull=True,
             type="R",
             validity_to__isnull=True,
-        ).order_by("code")
+        ).order_by("name")
 
     @classmethod
     def get_queryset(cls, queryset, info):

--- a/location/models.py
+++ b/location/models.py
@@ -456,6 +456,7 @@ class Location(core_models.VersionedModel, core_models.ExtendableModel):
     class Meta:
         managed = True
         db_table = "tblLocations"
+        ordering = ["name"]
 
 
 class Hotspot(core_models.VersionedModel, core_models.ExtendableModel):
@@ -745,8 +746,7 @@ class UserDistrict(core_models.VersionedModel):
                         *UserDistrict.filter_validity(),
                         *Location.filter_validity(prefix="location__"),
                     )
-                    .order_by("location__parent__code")
-                    .order_by("location__code")
+                    .order_by("location__parent__name", "location__name")
                 )
             for d in districts:
                 cachedata.append([d.id, d.location_id])
@@ -784,7 +784,7 @@ class UserDistrict(core_models.VersionedModel):
         return (
             Location.objects.filter(*Location.filter_validity())
             .filter(parent__parent__userdistrict__user=user.i_user)
-            .order_by("code")
+            .order_by("name")
         )
 
     @classmethod

--- a/location/models.py
+++ b/location/models.py
@@ -456,7 +456,6 @@ class Location(core_models.VersionedModel, core_models.ExtendableModel):
     class Meta:
         managed = True
         db_table = "tblLocations"
-        ordering = ["name"]
 
 
 class Hotspot(core_models.VersionedModel, core_models.ExtendableModel):

--- a/location/schema.py
+++ b/location/schema.py
@@ -70,9 +70,10 @@ class Query(graphene.ObjectType):
     locations_all = OrderedDjangoFilterConnectionField(
         LocationGQLType, orderBy=graphene.List(of_type=graphene.String)
     )
-    locations_str = DjangoFilterConnectionField(
+    locations_str = OrderedDjangoFilterConnectionField(
         LocationGQLType,
         str=graphene.String(),
+        orderBy=graphene.List(of_type=graphene.String),
     )
     user_districts = graphene.List(UserDistrictGQLType)
     officer_locations = graphene.List(

--- a/location/schema.py
+++ b/location/schema.py
@@ -254,8 +254,8 @@ class Query(graphene.ObjectType):
         if "location_type" in kwargs:
             return current_officer.officer_allowed_locations.filter(
                 type=kwargs["location_type"]
-            )
-        return current_officer.officer_allowed_locations
+            ).order_by("name")
+        return current_officer.officer_allowed_locations.order_by("name")
 
     def resolve_micro_catchments(self, info, **kwargs):
         show_history = kwargs.get("showHistory", False)

--- a/location/schema.py
+++ b/location/schema.py
@@ -133,7 +133,7 @@ class Query(graphene.ObjectType):
             hotspot = Hotspot.get_queryset(None, info.context.user).filter(
                 uuid=hotspot_uuid, validity_to__isnull=True
             ).first()
-        return get_hotspot_eligible_villages(micro_catchment, hotspot).order_by("code")
+        return get_hotspot_eligible_villages(micro_catchment, hotspot).order_by("name")
 
     def resolve_hotspots(self, info, **kwargs):
         if info.context.user.is_anonymous:


### PR DESCRIPTION
## Summary
Location filters/pickers currently return results in arbitrary DB order. This covers Phases 1, 2, and 5 of the location-filters alphabetical-ordering effort (`docs/location_filters_alphabetical_ordering.md` in the mthandizi umbrella repo), plus a follow-up fix from review.

- Sort `hotspotEligibleVillages`, `CatchmentGQLType.resolve_districts`, `UserDistrict.get_user_districts`/`get_user_locations` by `name` instead of `code` (Phase 2). Also fixes a real bug in `get_user_districts`: a second `.order_by()` call was silently overriding the first, so region/parent ordering was never actually applied.
- Promote `locations_str` to `OrderedDjangoFilterConnectionField` with an `orderBy` argument, so the frontend can request ascending/descending order instead of it being hardcoded (Phase 5 — enables the new sort toggle on `LocationPicker`/`LocationCascader` in the frontend PR).
- Sort `officerLocations` by `name` — it had no ordering at all, and callers had no way to request one either.

**Reverted:** an earlier commit added `Meta.ordering = ["name"]` to `Location` as a single default-ordering fix (originally Phase 1). Review (Shahzaibahmad97) found this silently broke `.distinct()` queries system-wide — Postgres requires `ORDER BY` columns to appear in `SELECT DISTINCT`, so Django injected `name` into every distinct clause, measured at 69,777 rows returned instead of 8,744 on the village queryset. Dropped; the explicit `.order_by`/`orderBy` changes above already cover the ordering this effort targets, `officerLocations` aside (see above).

## Known follow-up (not in this PR)
`UserDistrict.get_user_districts`'s result is cached per-user (`user_districts_{user.id}`) and isn't invalidated by this change — a deploy should flush that cache, or warm caches will keep serving the old `code` ordering for existing sessions.

## Test plan
- [x] Query `locations`, `locationsAll`, `locationsStr`, `officerLocations`, `hotspotEligibleVillages` via GraphiQL and confirm name-sorted results
- [x] Confirm `test_location_not_admin` (explicit `orderBy: "code"`) still passes — unaffected since a client-supplied `orderBy` still overrides
- [x] No `Meta.ordering` remains on `Location` — `.distinct()` callers (e.g. `household_validation/services.py:404`) are unaffected
